### PR TITLE
Update optimizer runs value to 100k

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         run: make anvil-test
 
       - name: Run Slither
-        uses: crytic/slither-action@v0.2.0
+        uses: crytic/slither-action@v0.3.0
         with:
           fail-on: none
 

--- a/foundry.toml
+++ b/foundry.toml
@@ -2,5 +2,6 @@
 src = 'src'
 out = 'out'
 libs = ['lib']
+optimizer_runs = 100000
 [fuzz]
 runs = 10000


### PR DESCRIPTION
Update optimizer runs value to 100k from default (200). This reduces code execution cost at expense of deploy size ([reference](https://docs.soliditylang.org/en/v0.8.17/internals/optimizer.html#optimizer-parameter-runs)).