### PR TITLE
ci: upgrade action versions to use node20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,12 +8,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: 'true'
 
       - name: Install Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
 
       - name: Install Solhint
         run: npm i


### PR DESCRIPTION
## Summary
Node 16 is EOL, upgrade action versions to use node 20

## Release Notes
* actions/checkout v3 -> v4: https://github.com/actions/checkout/releases/tag/v4.0.0
* actions/setup-node v3 -> v4: https://github.com/actions/setup-node/releases/tag/v4.0.0