### PR TITLE
[UNTRACKED] Allow users of this repository as a submodule to override the foundry version to use

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use fixed foundry image
-ARG FOUNDRY_VERSION=nightly-3fa02706ca732c994715ba42d923605692062375
+ARG FOUNDRY_VERSION=nightly-4a8c7d0e26a1befa526222e22737740f80a7f1c5
 
 FROM ghcr.io/foundry-rs/foundry:${FOUNDRY_VERSION}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 # Use fixed foundry image
+ARG FOUNDRY_VERSION=nightly-3fa02706ca732c994715ba42d923605692062375
 
-FROM ghcr.io/foundry-rs/foundry:nightly-4a8c7d0e26a1befa526222e22737740f80a7f1c5
+FROM ghcr.io/foundry-rs/foundry:${FOUNDRY_VERSION}
 
 # Copy our source code into the container
 WORKDIR /app


### PR DESCRIPTION
## Summary
Allow users of this repository as a submodule to override the foundry version to use

## Detail
This repository is used as a submodule elsewhere to build evm contracts, at the same time these other repositories install said contracts using a locally managed foundry version. when the versions don't align the builds can sometimes fail causing the need to cascade update the foundry version everywhere.

Allowing the Dockefile to use a build argument means other downstream repositories can update the version at their own pace without having to update this repository first.

## Testing
covered by existing tests

## Documentation

**Story:** [UNTRACKED](https://circlepay.atlassian.net/browse/)