### PR TITLE
chore(stepsecurity): update workflows to use custom hosted runners with built-in StepSecurity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,20 +5,20 @@ on:
     branches: [master]
 jobs:
   lint-and-test:
-    runs-on: ubuntu-latest
+    runs-on: github-hosted-small
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: 'true'
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.10'
 
       - name: Install Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
 
       - name: Install Solhint
         run: npm i
@@ -39,15 +39,15 @@ jobs:
         run: make anvil-test-v2
 
   analyze-message-transmitter:
-    runs-on: ubuntu-latest
+    runs-on: github-hosted-small
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: 'true'
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.10'
 
@@ -55,15 +55,15 @@ jobs:
         run: make analyze-message-transmitter
 
   analyze-message-transmitter-v2:
-    runs-on: ubuntu-latest
+    runs-on: github-hosted-small
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: 'true'
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.10'
 
@@ -71,15 +71,15 @@ jobs:
         run: make analyze-message-transmitter-v2
 
   analyze-token-messenger-minter:
-    runs-on: ubuntu-latest
+    runs-on: github-hosted-small
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: 'true'
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.10'
 


### PR DESCRIPTION
## Summary
This PR updates GitHub Actions workflows to use custom hosted runners that have StepSecurity built-in, removing the need for the explicit StepSecurity harden-runner action.

## What Changed
- Removed step-security/harden-runner action steps (no longer needed as StepSecurity is built into custom runners)
- Removed id-token: write permissions (no longer needed without the StepSecurity action)
- Updated runs-on from ubuntu-latest to github-hosted-small (custom runners with built-in StepSecurity)
- Converted non-circlefin action versions to commit SHAs with version comments for security pinning (e.g., actions/checkout@abc123 # v3.6.0)
- circlefin GitHub actions remain unchanged

## Purpose
Our custom hosted runners (github-hosted-small) now have StepSecurity built-in at the runner level, so we no longer need to add it as an explicit step in each workflow. This simplifies our workflows while maintaining the same security posture.

## Testing
- All workflow syntax changes have been validated
- No functional changes to workflow behavior
- StepSecurity protection is maintained via the custom runners
- Review the diff to ensure only intended changes occurred